### PR TITLE
removing version requirements so it works now

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,9 @@ dependencies:
   - Pillow
   - jupyterlab
   - nbconvert
+  - jupyterlab-git
+  - jupyterlab_miami_nights 
   - pip:
       - geonamescache
       - jupyterlab_tabnine
+      - jupyterlab_github

--- a/environment.yml
+++ b/environment.yml
@@ -2,19 +2,19 @@ name: discovering-disease-outbreaks
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - pandas=0.25.0
-  - numpy=1.16.0
-  - scikit-learn=0.20.3
-  - basemap=1.2.1
-  - black=19.3b0
-  - matplotlib=3.1.1
-  - seaborn=0.9.0
-  - Unidecode=1.1.1
-  - pip=19.2.3
-  - Pillow=6.1.0
-  - jupyter=1.0.0
-  - jupyter_contrib_nbextensions=0.5.1
-  - nbconvert=5.6.0
+  - python
+  - pandas
+  - numpy
+  - scikit-learn
+  - basemap
+  - black
+  - matplotlib
+  - seaborn
+  - Unidecode
+  - pip
+  - Pillow
+  - jupyter
+  - jupyter_contrib_nbextensions
+  - nbconvert
   - pip:
-      - geonamescache==1.1.0
+      - geonamescache

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - Unidecode
   - pip
   - Pillow
-  - jupyter
-  - jupyter_contrib_nbextensions
+  - jupyterlab
   - nbconvert
   - pip:
       - geonamescache
+      - jupyterlab_tabnine


### PR DESCRIPTION
I tried setting up a Conda environment and got errors around `jupyter_contrib_nbextensions` not being available.
Removed all version specifications and the environment has now been successfully created (on OS X.)